### PR TITLE
Fix notes for lost braces check on CRAN

### DIFF
--- a/man/downscale.Rd
+++ b/man/downscale.Rd
@@ -67,7 +67,7 @@ Nine downscaling models are available (and also see \code{\link{hui.downscale}} 
 }
 \if{latex}{\figure{Equations.png}{options: width=13cm}}
 
-The finite negative binomial model (\code{"FNB"}) incorporates several gamma functions. This may result in integers larger than is possible to store in R. Therefore multiple precision floating point numbers (\code{\link{mpfr}} function in package \pkg{Rmpfr}) are used to make calculations possible.
+The finite negative binomial model (\code{"FNB"}) incorporates several gamma functions. This may result in integers larger than is possible to store in R. Therefore multiple precision floating point numbers (\code{\link[Rmpfr]{mpfr}} function in package \pkg{Rmpfr}) are used to make calculations possible.
 
 The Thomas model incorporates spatial point processes in order to estimate species aggregations. This involves multi-dimensional integration which may be time-consuming. Users can alter the tolerance value during the integration process - a smaller value will give more accurate estimates but longer processing times.
  

--- a/man/downscale.Rd
+++ b/man/downscale.Rd
@@ -6,7 +6,7 @@ downscale(occupancies, model, extent = NULL, tolerance = 1e-06,
           starting_params = NULL)
 }
 \arguments{
-\item{occupancies}{Either a data frame containing two columns or an object of class \code{"upgrain"} from the \code{\link{upgrain}} function. If using a data frame the first column must be the grain sizes (cell area in squared units e.g. km^{2}). The second column is the proportion of occupancies at each grain size.}
+\item{occupancies}{Either a data frame containing two columns or an object of class \code{"upgrain"} from the \code{\link{upgrain}} function. If using a data frame the first column must be the grain sizes (cell area in squared units e.g. \eqn{km^2}). The second column is the proportion of occupancies at each grain size.}
 
 \item{model}{selected downscaling model, chosen from one of \code{"Nachman"},
 \code{"PL"}, \code{"Logis"}, \code{"Poisson"}, \code{"NB"}, \code{"GNB"},

--- a/man/ensemble.downscale.Rd
+++ b/man/ensemble.downscale.Rd
@@ -8,9 +8,9 @@ ensemble.downscale(occupancies, new.areas, extent, cell.width = NULL,
                    verbose = TRUE)
 }
 \arguments{
-\item{occupancies}{Either a data frame containing two columns or an object of class "upgrain" from the upgrain function. If using the \code{Hui} model (or \code{model = "all"}) occupancies must be of class \code{"upgrain"}. If using a data frame the first column must be the grain sizes (cell area in squared units e.g. km^2). The second column is the proportion of occupancies at each grain size.}
+\item{occupancies}{Either a data frame containing two columns or an object of class "upgrain" from the upgrain function. If using the \code{Hui} model (or \code{model = "all"}) occupancies must be of class \code{"upgrain"}. If using a data frame the first column must be the grain sizes (cell area in squared units e.g. \eqn{km^2}). The second column is the proportion of occupancies at each grain size.}
 
-\item{new.areas}{vector of grain sizes (in squared units e.g. km^{2}) for which area of occupancy will be predicted.}
+\item{new.areas}{vector of grain sizes (in squared units e.g. \eqn{km^2}) for which area of occupancy will be predicted.}
 
 \item{extent}{total area in same units as occupancy. If using an object of class "upgrain", this is automatically inputted.}
 

--- a/man/hui.downscale.Rd
+++ b/man/hui.downscale.Rd
@@ -10,7 +10,7 @@ hui.downscale(atlas.data, cell.width, new.areas, extent = NULL,
 
 \item{cell.width}{the cell width of the atlas data.}
 
-\item{new.areas}{vector of grain sizes as cell area (in same units as cell.width but squared e.g. km^{2}) at fine scales for model prediction.}
+\item{new.areas}{vector of grain sizes as cell area (in same units as cell.width but squared e.g. \eqn{km^2}) at fine scales for model prediction.}
 
 \item{extent}{the extent of the atlas data in same units as \code{cell.areas}. If the input data is of class \code{"upgrain"} this can be left as \code{NULL}.}
 

--- a/man/predict.downscale.Rd
+++ b/man/predict.downscale.Rd
@@ -7,7 +7,7 @@
 \arguments{
 \item{object}{a fitted object of class \code{'downscale'}.}
 
-\item{new.areas}{vector of grain sizes (in squared units e.g. km^{2}) for which area of occupancy will be predicted.}
+\item{new.areas}{vector of grain sizes (in squared units e.g. \eqn{km^2}) for which area of occupancy will be predicted.}
 
 \item{tolerance}{only applicable for the \code{Thomas} model. The tolerance used during integration in the Thomas model during optimisation of parameters. Lower numbers allow for greater accuracy but require longer processing times (default = \code{1e-6}).}
 


### PR DESCRIPTION
Source: https://cran.r-project.org/web/checks/check_results_downscale.html

```
Version: 5.0.0
Check: Rd files
Result: NOTE 
  checkRd: (-1) downscale.Rd:9: Lost braces; missing escapes or markup?
       9 | \item{occupancies}{Either a data frame containing two columns or an object of class \code{"upgrain"} from the \code{\link{upgrain}} function. If using a data frame the first column must be the grain sizes (cell area in squared units e.g. km^{2}). The second column is the proportion of occupancies at each grain size.}
         |                                                                                                                                                                                                                                                  ^
  checkRd: (-1) ensemble.downscale.Rd:13: Lost braces; missing escapes or markup?
      13 | \item{new.areas}{vector of grain sizes (in squared units e.g. km^{2}) for which area of occupancy will be predicted.}
         |                                                                  ^
  checkRd: (-1) hui.downscale.Rd:13: Lost braces; missing escapes or markup?
      13 | \item{new.areas}{vector of grain sizes as cell area (in same units as cell.width but squared e.g. km^{2}) at fine scales for model prediction.}
         |                                                                                                      ^
  checkRd: (-1) predict.downscale.Rd:10: Lost braces; missing escapes or markup?
      10 | \item{new.areas}{vector of grain sizes (in squared units e.g. km^{2}) for which area of occupancy will be predicted.}
         |                                                                  ^
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/downscale-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/downscale-00check.html), [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/downscale-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/downscale-00check.html), [r-devel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/downscale-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/downscale-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/downscale-00check.html), [r-release-macos-arm64](https://www.r-project.org/nosvn/R.check/r-release-macos-arm64/downscale-00check.html), [r-release-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-release-macos-x86_64/downscale-00check.html), [r-release-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-release-windows-x86_64/downscale-00check.html), [r-oldrel-macos-arm64](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-arm64/downscale-00check.html), [r-oldrel-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-x86_64/downscale-00check.html), [r-oldrel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-oldrel-windows-x86_64/downscale-00check.html)

Version: 5.0.0
Check: Rd cross-references
Result: NOTE 
  Found the following Rd file(s) with Rd \link{} targets missing package
  anchors:
    downscale.Rd: mpfr
  Please provide package anchors for all Rd \link{} targets not in the
  package itself and the base packages.
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/downscale-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/downscale-00check.html), [r-devel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/downscale-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/downscale-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/downscale-00check.html), [r-release-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-release-windows-x86_64/downscale-00check.html)
```